### PR TITLE
fix(docs): default config path

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Some details:
         foo.bar
 
 - The rule `level` is also **optional** (the default rule level is "error").
-- See [the default configuration](src/main/java/resources/conf/default.yaml) to get the default rules' parameter values.
+- See [the default configuration](src/main/resources/conf/default.yaml) to get the default rules' parameter values.
 
 ## Batch usage
 


### PR DESCRIPTION
Path returns a 404 for the default config.